### PR TITLE
Issue #69: Refactors method `_shiftDown` in `Graphs/PrimMST.js`

### DIFF
--- a/Graphs/PrimMST.js
+++ b/Graphs/PrimMST.js
@@ -44,6 +44,7 @@ class PriorityQueue {
   }
 
   getPriorityOrInfinite (position) {
+    // Returns priority of the node, or Infinite if no node corresponds to this position
     if (position >= 0 && position < this._heap.length) {
       return this._heap[position][1]
     }

--- a/Graphs/PrimMST.js
+++ b/Graphs/PrimMST.js
@@ -1,3 +1,5 @@
+import { info } from "console"
+
 // Priority Queue Helper functions
 function getParentPosition (position) {
   // Get the parent node of the current node
@@ -41,24 +43,25 @@ class PriorityQueue {
     return (key in this.keys)
   }
 
+  getPriorityOrInfinite (position) {
+    if (position >= 0 && position < this._heap.length) {
+      return this._heap[position][1]
+    }
+    else {
+      return Infinity
+    }
+  }
+
   update (key, priority) {
     // Update the priority of the given element (equivalent to decreaseKey)
     const currPos = this.keys[key]
     this._heap[currPos][1] = priority
     const parentPos = getParentPosition(currPos)
-    const currPriority = this._heap[currPos][1]
-    let parentPriority = Infinity
-    if (parentPos >= 0) {
-      parentPriority = this._heap[parentPos][1]
-    }
+    const currPriority = this.getPriorityOrInfinite(currPos)
+    const parentPriority = this.getPriorityOrInfinite(parentPos)
     const [child1Pos, child2Pos] = getChildrenPosition(currPos)
-    let [child1Priority, child2Priority] = [Infinity, Infinity]
-    if (child1Pos < this._heap.length) {
-      child1Priority = this._heap[child1Pos][1]
-    }
-    if (child2Pos < this._heap.length) {
-      child2Priority = this._heap[child2Pos][1]
-    }
+    const child1Priority = this.getPriorityOrInfinite(child1Pos)
+    const child2Priority = this.getPriorityOrInfinite(child2Pos)
 
     if (parentPos >= 0 && parentPriority > currPriority) {
       this._shiftUp(currPos)
@@ -68,35 +71,20 @@ class PriorityQueue {
     }
   }
 
-  _getPriorityOrInfinite (position) {
-    if (position >= 0 && position < this._heap.length) {
-      return this._heap[position][1]
-    }
-    else {
-      return Infinity
-    }
-  }
-
   _shiftUp (position) {
     // Helper function to shift up a node to proper position (equivalent to bubbleUp)
     let currPos = position
     let parentPos = getParentPosition(currPos)
-    let currPriority = this._heap[currPos][1]
-    let parentPriority = Infinity
-    if (parentPos >= 0) {
-      parentPriority = this._heap[parentPos][1]
-    }
+    let currPriority = this.getPriorityOrInfinite(currPos)
+    let parentPriority = this.getPriorityOrInfinite(parentPos)
 
     while (parentPos >= 0 && parentPriority > currPriority) {
       this._swap(currPos, parentPos)
       currPos = parentPos
       parentPos = getParentPosition(currPos)
-      currPriority = this._heap[currPos][1]
-      try {
-        parentPriority = this._heap[parentPos][1]
-      } catch (error) {
-        parentPriority = Infinity
-      }
+      currPriority = this.getPriorityOrInfinite(currPos)
+      parentPriority = this.getPriorityOrInfinite(parentPos)
+
     }
     this.keys[this._heap[currPos][0]] = currPos
   }
@@ -105,19 +93,14 @@ class PriorityQueue {
     // Helper function to shift down a node to proper position (equivalent to bubbleDown)
     let currPos = position
     let [child1Pos, child2Pos] = getChildrenPosition(currPos)
-    let [child1Priority, child2Priority] = [Infinity, Infinity]
-    if (child1Pos < this._heap.length) {
-      child1Priority = this._heap[child1Pos][1]
-    }
-    if (child2Pos < this._heap.length) {
-      child2Priority = this._heap[child2Pos][1]
-    }
-    let currPriority
-    try {
-      currPriority = this._heap[currPos][1]
-    } catch {
+    let child1Priority = this.getPriorityOrInfinite(child1Pos)
+    let child2Priority = this.getPriorityOrInfinite(child2Pos)
+    let currPriority = this.getPriorityOrInfinite(currPos)
+
+    if (currPriority == Infinity) {
       return
     }
+
 
     while (child2Pos < this._heap.length &&
       (child1Priority < currPriority || child2Priority < currPriority)) {
@@ -129,20 +112,9 @@ class PriorityQueue {
         currPos = child2Pos
       }
       [child1Pos, child2Pos] = getChildrenPosition(currPos)
-      try {
-        child1Priority = this._heap[child1Pos][1]
-      }
-      catch (error) {
-        child1Priority = Infinity
-      }
-      try {
-        child2Priority = this._heap[child2Pos][1]
-      }
-      catch (error) {
-        child2Priority = Infinity
-      }
-
-      currPriority = this._heap[currPos][1]
+      child1Priority = this.getPriorityOrInfinite(child1Pos)
+      child2Priority = this.getPriorityOrInfinite(child2Pos)
+      currPriority = this.getPriorityOrInfinite(currPos)
     }
     this.keys[this._heap[currPos][0]] = currPos
     if (child1Pos < this._heap.length && child1Priority < currPriority) {

--- a/Graphs/PrimMST.js
+++ b/Graphs/PrimMST.js
@@ -102,8 +102,7 @@ class PriorityQueue {
     }
 
 
-    while (child2Pos < this._heap.length &&
-      (child1Priority < currPriority || child2Priority < currPriority)) {
+    while ((child1Priority < currPriority || child2Priority < currPriority)) {
       if (child1Priority < currPriority && child1Priority < child2Priority) {
         this._swap(child1Pos, currPos)
         currPos = child1Pos
@@ -117,7 +116,7 @@ class PriorityQueue {
       currPriority = this.getPriorityOrInfinite(currPos)
     }
     this.keys[this._heap[currPos][0]] = currPos
-    if (child1Pos < this._heap.length && child1Priority < currPriority) {
+    if (child1Priority < currPriority) {
       this._swap(child1Pos, currPos)
       this.keys[this._heap[child1Pos][0]] = child1Pos
     }

--- a/Graphs/PrimMST.js
+++ b/Graphs/PrimMST.js
@@ -66,8 +66,7 @@ class PriorityQueue {
 
     if (parentPos >= 0 && parentPriority > currPriority) {
       this._shiftUp(currPos)
-    } else if (child2Pos < this._heap.length &&
-      (child1Priority < currPriority || child2Priority < currPriority)) {
+    } else if (child1Priority < currPriority || child2Priority < currPriority) {
       this._shiftDown(currPos)
     }
   }
@@ -102,7 +101,7 @@ class PriorityQueue {
       return
     }
 
-    while ((child1Priority < currPriority || child2Priority < currPriority)) {
+    while (child1Priority < currPriority || child2Priority < currPriority) {
       if (child1Priority < currPriority && child1Priority < child2Priority) {
         this._swap(child1Pos, currPos)
         currPos = child1Pos

--- a/Graphs/PrimMST.js
+++ b/Graphs/PrimMST.js
@@ -102,7 +102,6 @@ class PriorityQueue {
       return
     }
 
-
     while ((child1Priority < currPriority || child2Priority < currPriority)) {
       if (child1Priority < currPriority && child1Priority < child2Priority) {
         this._swap(child1Pos, currPos)
@@ -115,11 +114,6 @@ class PriorityQueue {
       child1Priority = this.getPriorityOrInfinite(child1Pos)
       child2Priority = this.getPriorityOrInfinite(child2Pos)
       currPriority = this.getPriorityOrInfinite(currPos)
-    }
-    this.keys[this._heap[currPos][0]] = currPos
-    if (child1Priority < currPriority) {
-      this._swap(child1Pos, currPos)
-      this.keys[this._heap[child1Pos][0]] = child1Pos
     }
   }
 

--- a/Graphs/PrimMST.js
+++ b/Graphs/PrimMST.js
@@ -68,6 +68,15 @@ class PriorityQueue {
     }
   }
 
+  _getPriorityOrInfinite (position) {
+    if (position >= 0 && position < this._heap.length) {
+      return this._heap[position][1]
+    }
+    else {
+      return Infinity
+    }
+  }
+
   _shiftUp (position) {
     // Helper function to shift up a node to proper position (equivalent to bubbleUp)
     let currPos = position

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ A refactoring plan could be to:
 - add an auxiliary function to compute the priority of the children of a node
 - remove all assertions like `child2Pos < this._heap.length` which would also avoid the last if statement
 
-The refactoring was done in this [commit](https://github.com/Xolvez/DD2480-JavaScript/commit/c0082721cc4d026f1d0e0194ccfe569c747ccf8d). It decreased the CCN of the method _shiftDown from 13 to 7, along with a big reduce in NLOC (from 46 to 28).
+The refactoring was done in this [commit](https://github.com/Xolvez/DD2480-JavaScript/commit/0600e9aa6bd6dccab7a9bb9a3edd7e81d88bd881). It decreased the CCN of the method _shiftDown from 13 to 6, along with a big reduce in NLOC (from 46 to 23).
 
 ## Coverage
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ A refactoring plan could be to:
 - add an auxiliary function to compute the priority of the children of a node
 - remove all assertions like `child2Pos < this._heap.length` which would also avoid the last if statement
 
-The refactoring was done in this [commit](https://github.com/Xolvez/DD2480-JavaScript/commit/0600e9aa6bd6dccab7a9bb9a3edd7e81d88bd881). It decreased the CCN of the method _shiftDown from 13 to 6, along with a big reduce in NLOC (from 46 to 23).
+The refactoring was carried out in this [commit](https://github.com/Xolvez/DD2480-JavaScript/commit/0600e9aa6bd6dccab7a9bb9a3edd7e81d88bd881). It decreased the CCN of the method _shiftDown from 13 to 6, along with a big reduce in NLOC (from 46 to 23).
 
 ## Coverage
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This function can be refactored by replacing the `if-else` statements with five 
 And since the invalid input is checked before this function is called(`hueSection` < 0 and `hueSection` > 6), we don't need to check them again.
 Making this adjustment can cut the cyclomatic complexity from 11 to 5.
 
-#### Function `PrimMST._shiftDown`:
+#### Function `PrimMST._shiftDown` (from 13 CCN to 7 CCN):
 
 The complexity of the function comes mainly from two things:
 - computation of the priorities of the children of a node, which is done multiple times
@@ -158,6 +158,8 @@ The complexity of the function comes mainly from two things:
 A refactoring plan could be to:
 - add an auxiliary function to compute the priority of the children of a node
 - remove all assertions like `child2Pos < this._heap.length` which would also avoid the last if statement
+
+The refactoring was done in this [commit](https://github.com/Xolvez/DD2480-JavaScript/commit/c0082721cc4d026f1d0e0194ccfe569c747ccf8d). It decreased the CCN of the method _shiftDown from 13 to 7, along with a big reduce in NLOC (from 46 to 28).
 
 ## Coverage
 


### PR DESCRIPTION
Here are the main changes of the refactor: 

- adds method `getPriorityOrInfinite` to compute the priority of a node (eventually infinite if it doesn't exist)
- changes methods `_shiftDown`, `_shiftUp` and update to call `getPriorityOrInfinite`
- removes useless clauses of if statements in `_shiftDown`

The result of the refactor is documented in the ReadMe:

- CCN decreased from 13 to 6
- NLOC decreased from 46 to 23